### PR TITLE
Support multi-thread

### DIFF
--- a/CBBDataBus.podspec
+++ b/CBBDataBus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "CBBDataBus"
-  s.version = "2.0.0"
+  s.version = "2.1.0"
   s.summary = "DataBus for iOS"
   s.homepage = "https://github.com/cross-border-bridge/data-bus-ios"
   s.author = 'DWANGO Co., Ltd.'

--- a/CBBDataBus/CBBDataBus.h
+++ b/CBBDataBus/CBBDataBus.h
@@ -4,7 +4,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NSInteger CBBDataBusHandlerId;
 typedef void (^CBBDataBusHandler)(NSArray* data);
 
 @interface CBBDataBus : NSObject

--- a/CBBDataBus/CBBDataBus.h
+++ b/CBBDataBus/CBBDataBus.h
@@ -9,11 +9,12 @@ typedef void (^CBBDataBusHandler)(NSArray* data);
 
 @interface CBBDataBus : NSObject
 @property (readonly, nonatomic) BOOL destroyed;
-@property (readonly, nonatomic) NSMutableArray<CBBDataBusHandler>* handlers;
 - (void)sendData:(NSArray*)data;
+- (void)onReceiveData:(NSArray*)data;
 - (void)addHandler:(CBBDataBusHandler)handler;
 - (void)removeHandler:(CBBDataBusHandler)handler;
 - (void)removeAllHandlers;
+- (NSInteger)getHandlerCount;
 - (void)destroy;
 @end
 

--- a/CBBDataBus/CBBDataBus.h
+++ b/CBBDataBus/CBBDataBus.h
@@ -8,12 +8,12 @@ typedef void (^CBBDataBusHandler)(NSArray* data);
 
 @interface CBBDataBus : NSObject
 @property (readonly, nonatomic) BOOL destroyed;
+@property (nonatomic, readonly) NSInteger handlerCount;
 - (void)sendData:(NSArray*)data;
 - (void)onReceiveData:(NSArray*)data;
 - (void)addHandler:(CBBDataBusHandler)handler;
 - (void)removeHandler:(CBBDataBusHandler)handler;
 - (void)removeAllHandlers;
-- (NSInteger)getHandlerCount;
 - (void)destroy;
 @end
 

--- a/CBBDataBus/CBBDataBus.m
+++ b/CBBDataBus/CBBDataBus.m
@@ -5,7 +5,6 @@
 @interface CBBDataBus ()
 @property (readwrite, nonatomic) BOOL destroyed;
 @property (readwrite, atomic) NSMutableArray<CBBDataBusHandler>* handlers;
-@property (atomic) CBBDataBusHandlerId nextHandlerId;
 @end
 
 @implementation CBBDataBus
@@ -13,7 +12,6 @@
 - (instancetype)init
 {
     if (self = [super init]) {
-        _nextHandlerId = 1;
         _handlers = [NSMutableArray array];
     }
     return self;

--- a/CBBDataBus/CBBDataBus.m
+++ b/CBBDataBus/CBBDataBus.m
@@ -71,7 +71,7 @@
     }
 }
 
-- (NSInteger)getHandlerCount
+- (NSInteger)handlerCount
 {
     NSInteger result;
     @synchronized (self) {

--- a/CBBDataBus/CBBDataBus.m
+++ b/CBBDataBus/CBBDataBus.m
@@ -4,7 +4,7 @@
 
 @interface CBBDataBus ()
 @property (readwrite, nonatomic) BOOL destroyed;
-@property (readwrite, atomic) NSMutableArray<CBBDataBusHandler>* handlers;
+@property (readwrite, nonatomic) NSMutableArray<CBBDataBusHandler>* handlers;
 @end
 
 @implementation CBBDataBus
@@ -82,7 +82,9 @@
 
 - (void)destroy
 {
-    _handlers = nil;
+    @synchronized (self) {
+        _handlers = nil;
+    }
     _destroyed = YES;
 }
 

--- a/CBBDataBus/CBBDataBus.m
+++ b/CBBDataBus/CBBDataBus.m
@@ -27,11 +27,12 @@
     if (_destroyed) {
         return;
     }
+    NSArray* handlers;
     @synchronized (self) {
-        NSArray* handlers = [_handlers copy];
-        for (CBBDataBusHandler handler in handlers) {
-            handler(data);
-        }
+        handlers = [_handlers copy];
+    }
+    for (CBBDataBusHandler handler in handlers) {
+        handler(data);
     }
 }
 

--- a/CBBDataBus/CBBDataBus.m
+++ b/CBBDataBus/CBBDataBus.m
@@ -30,7 +30,8 @@
         return;
     }
     @synchronized (self) {
-        for (CBBDataBusHandler handler in _handlers) {
+        NSArray* handlers = [_handlers copy];
+        for (CBBDataBusHandler handler in handlers) {
             handler(data);
         }
     }

--- a/CBBDataBus/CBBMemoryQueueDataBus.m
+++ b/CBBDataBus/CBBMemoryQueueDataBus.m
@@ -14,11 +14,12 @@
 - (instancetype)initWithSender:(CBBMemoryQueue*)sender
                       receiver:(CBBMemoryQueue*)receiver
 {
+    __weak typeof(self) weakSelf = self;
     if ([super init]) {
         _sender = sender;
         _receiver = receiver;
         _receiver.handler = ^(NSArray* data) {
-            [super onReceiveData:data];
+            [weakSelf onReceiveData:data];
         };
     }
     return self;

--- a/CBBDataBus/CBBMemoryQueueDataBus.m
+++ b/CBBDataBus/CBBMemoryQueueDataBus.m
@@ -5,6 +5,7 @@
 
 @interface CBBMemoryQueueDataBus ()
 @property (readwrite, nonnull) CBBMemoryQueue* sender;
+@property (readwrite, nonnull) CBBMemoryQueue* receiver;
 @property (readwrite, nonnull) CBBMemoryQueueHandler handler;
 @end
 
@@ -14,8 +15,9 @@
                       receiver:(CBBMemoryQueue*)receiver
 {
     if ([super init]) {
-        self.sender = sender;
-        receiver.handler = ^(NSArray* data) {
+        _sender = sender;
+        _receiver = receiver;
+        _receiver.handler = ^(NSArray* data) {
             [super onReceiveData:data];
         };
     }
@@ -25,6 +27,21 @@
 - (void)sendData:(NSArray*)data
 {
     [_sender sendData:data];
+}
+
+- (void)destroy
+{
+    _sender = nil;
+    if (_receiver) {
+        _receiver.handler = nil;
+        _receiver = nil;
+    }
+    [super destroy];
+}
+
+- (void)dealloc
+{
+    [self destroy];
 }
 
 @end

--- a/CBBDataBus/CBBMemoryQueueDataBus.m
+++ b/CBBDataBus/CBBMemoryQueueDataBus.m
@@ -14,10 +14,10 @@
 - (instancetype)initWithSender:(CBBMemoryQueue*)sender
                       receiver:(CBBMemoryQueue*)receiver
 {
-    __weak typeof(self) weakSelf = self;
-    if ([super init]) {
+    if (self = [super init]) {
         _sender = sender;
         _receiver = receiver;
+        __weak typeof(self) weakSelf = self;
         _receiver.handler = ^(NSArray* data) {
             [weakSelf onReceiveData:data];
         };

--- a/CBBDataBus/CBBMemoryQueueDataBus.m
+++ b/CBBDataBus/CBBMemoryQueueDataBus.m
@@ -16,9 +16,7 @@
     if ([super init]) {
         self.sender = sender;
         receiver.handler = ^(NSArray* data) {
-            for (CBBDataBusHandler handler in super.handlers) {
-                handler(data);
-            }
+            [super onReceiveData:data];
         };
     }
     return self;

--- a/CBBDataBus/CBBMultiplexDataBus.m
+++ b/CBBDataBus/CBBMultiplexDataBus.m
@@ -18,7 +18,7 @@
         _dataId = dataId;
         __weak typeof(self) weakSelf = self;
         _handler = ^(NSArray* packet) {
-            if ([weakSelf destroyed] || [weakSelf getHandlerCount] < 1) {
+            if ([weakSelf destroyed] || weakSelf.handlerCount < 1) {
                 return;
             }
             if (packet.count < 1 || ![_dataId isEqualToString:packet[0]]) {

--- a/CBBDataBus/CBBMultiplexDataBus.m
+++ b/CBBDataBus/CBBMultiplexDataBus.m
@@ -16,9 +16,9 @@
     if (self = [super init]) {
         _dataBus = dataBus;
         _dataId = dataId;
-        __weak id __self = self;
+        __weak typeof(self) weakSelf = self;
         _handler = ^(NSArray* packet) {
-            if ([__self destroyed] || [__self getHandlerCount] < 1) {
+            if ([weakSelf destroyed] || [weakSelf getHandlerCount] < 1) {
                 return;
             }
             if (packet.count < 1 || ![_dataId isEqualToString:packet[0]]) {
@@ -28,7 +28,7 @@
             for (int i = 1; i < packet.count; i++) {
                 [data addObject:packet[i]];
             }
-            [__self onReceiveData:data];
+            [weakSelf onReceiveData:data];
         };
         [_dataBus addHandler:_handler];
     }

--- a/CBBDataBus/CBBMultiplexDataBus.m
+++ b/CBBDataBus/CBBMultiplexDataBus.m
@@ -16,10 +16,9 @@
     if (self = [super init]) {
         _dataBus = dataBus;
         _dataId = dataId;
-        __weak NSArray<CBBDataBusHandler>* __handlers = self.handlers;
         __weak id __self = self;
         _handler = ^(NSArray* packet) {
-            if ([__self destroyed] || __handlers.count < 1) {
+            if ([__self destroyed] || [__self getHandlerCount] < 1) {
                 return;
             }
             if (packet.count < 1 || ![_dataId isEqualToString:packet[0]]) {
@@ -29,9 +28,7 @@
             for (int i = 1; i < packet.count; i++) {
                 [data addObject:packet[i]];
             }
-            for (CBBDataBusHandler handler in __handlers) {
-                handler(data);
-            }
+            [__self onReceiveData:data];
         };
         [_dataBus addHandler:_handler];
     }

--- a/CBBDataBus/CBBWKWebViewDataBus.m
+++ b/CBBDataBus/CBBWKWebViewDataBus.m
@@ -162,9 +162,7 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
 
 - (void)_processReceiveArguments:(NSArray*)data
 {
-    for (CBBDataBusHandler handler in super.handlers) {
-        handler(data);
-    }
+    [super onReceiveData:data];
 }
 
 #pragma mark - KVO

--- a/CBBDataBus/CBBWKWebViewDataBus.m
+++ b/CBBDataBus/CBBWKWebViewDataBus.m
@@ -162,7 +162,7 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
 
 - (void)_processReceiveArguments:(NSArray*)data
 {
-    [super onReceiveData:data];
+    [self onReceiveData:data];
 }
 
 #pragma mark - KVO

--- a/CBBDataBusTests/DataBusTests.m
+++ b/CBBDataBusTests/DataBusTests.m
@@ -102,7 +102,7 @@
                 _counter++;
                 // send B -> A
                 [_dataBusB sendData:@[ @"HELLO", @"THIS", @"IS", @"B", @(2222) ]];
-                // [_dataBusB removeHandler:handler];
+                [_dataBusB removeHandler:handler];
             };
             [_dataBusB addHandler:handler];
         }];

--- a/CBBDataBusTests/DataBusTests.m
+++ b/CBBDataBusTests/DataBusTests.m
@@ -67,4 +67,60 @@
     [_dataBusB destroy];
 }
 
+- (void)testMultiThread
+{
+    _counter = 0;
+    
+    _dataBusA = [[CBBMemoryQueueDataBus alloc] initWithSender:_mqA receiver:_mqB];
+    [_dataBusA addHandler:^(NSArray* _Nonnull data) {
+        NSLog(@"dataBusA received: %@", data);
+        // [A] expects message from [B]
+        XCTAssertEqualObjects(data[0], @"HELLO");
+        XCTAssertEqualObjects(data[1], @"THIS");
+        XCTAssertEqualObjects(data[2], @"IS");
+        XCTAssertEqualObjects(data[3], @"B");
+        XCTAssertEqualObjects(data[4], @(2222));
+        _counter++;
+    }];
+    
+    _dataBusB = [[CBBMemoryQueueDataBus alloc] initWithSender:_mqB receiver:_mqA];
+
+    const int threadNumber = 10;
+    NSOperationQueue* threads[threadNumber];
+
+    for (int i = 0; i < threadNumber; i++) {
+        threads[i] = [[NSOperationQueue alloc] init];
+        [threads[i] addOperationWithBlock:^{
+            CBBDataBusHandler handler = ^(NSArray* _Nonnull data) {
+                NSLog(@"dataBusB received: %@", data);
+                // [B] expects message from [A]
+                XCTAssertEqualObjects(data[0], @"Hello");
+                XCTAssertEqualObjects(data[1], @"This");
+                XCTAssertEqualObjects(data[2], @"is");
+                XCTAssertEqualObjects(data[3], @"A");
+                XCTAssertEqualObjects(data[4], @(1111));
+                _counter++;
+                // send B -> A
+                [_dataBusB sendData:@[ @"HELLO", @"THIS", @"IS", @"B", @(2222) ]];
+                // [_dataBusB removeHandler:handler];
+            };
+            [_dataBusB addHandler:handler];
+        }];
+    }
+
+    // join
+    for (int i = 0; i < threadNumber; i++) {
+        [threads[i] waitUntilAllOperationsAreFinished];
+    }
+
+    // send A -> B
+    [_dataBusA sendData:@[ @"Hello", @"This", @"is", @"A", @(1111) ]];
+
+    
+    XCTAssertEqual(_counter, threadNumber * 2);
+    
+    [_dataBusA destroy];
+    [_dataBusB destroy];
+}
+
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Change log
 
+## Version 2.1.0
+- マルチスレッドに対応
+- `DataBus#handler` を DataBus実装から参照する方式を廃止 (破壊的変更)
+  - DataBus実装はデータ到達時に `DataBus#onReceiveData` を呼ぶものとする
+  - この変更は, 独自のDataBus実装開発者に影響する
+
 ## Version 2.0.0
 初版

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ open Example.xcworkspace
 ### Podfile
 ```
 abstract_target 'defaults' do
-    pod 'CBBDataBus', '~2.0.0'
+    pod 'CBBDataBus', '~2.1.0'
 end
 ```
 


### PR DESCRIPTION
複数スレッドからDataBusの操作を行うことができない問題を対策します。

この対策に伴い, DataBus実装の仕様を次のように変更します:
- before: DataBus実装はデータ受信時に基本クラスのhandlersに登録されているハンドラを呼び出す
- after: DataBus実装はデータ受信時に基本クラスのonReceiveDataを呼び出す