### PR TITLE
swiftでコンパイル時に警告が出ないようにする

### DIFF
--- a/CBBDataBus.podspec
+++ b/CBBDataBus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "CBBDataBus"
-  s.version = "2.1.1"
+  s.version = "2.1.2"
   s.summary = "DataBus for iOS"
   s.homepage = "https://github.com/cross-border-bridge/data-bus-ios"
   s.author = 'DWANGO Co., Ltd.'

--- a/CBBDataBus/CBBWKWebViewDataBus.m
+++ b/CBBDataBus/CBBWKWebViewDataBus.m
@@ -154,7 +154,8 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
         }
         if (data) {
             NSString* script = [NSString stringWithFormat:@"CBB.WebViewDataBus.onData(%@);", data];
-            [weakSelf.webView evaluateJavaScript:script completionHandler:weakSelf.evaluateJavaScript];
+            [weakSelf.webView evaluateJavaScript:script
+                               completionHandler:weakSelf.evaluateJavaScript];
         } else {
             completionHandler();
         }

--- a/CBBDataBus/CBBWKWebViewDataBus.m
+++ b/CBBDataBus/CBBWKWebViewDataBus.m
@@ -13,7 +13,6 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
 @property (nonatomic) BOOL dataBusFound;
 @property (nonatomic) BOOL consumingRequests;
 @property (nonatomic) void (^evaluateJavaScript)(id, NSError*);
-@property (nonatomic) NSLock* evaluateJavaScriptLocker;
 @end
 
 @implementation CBBWKWebViewDataBus
@@ -29,7 +28,6 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
         _webView = webView;
         _mode = mode;
         _pendingRequests = [NSMutableArray array];
-        _evaluateJavaScriptLocker = [[NSLock alloc] init];
         [self injectCBBDataBus];
     }
     return self;
@@ -142,7 +140,6 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
         return;
     }
 
-    [_evaluateJavaScriptLocker lock];
     __weak __typeof(self) weakSelf = self;
     _evaluateJavaScript = ^(id ret, NSError* error) {
         NSString* data;
@@ -161,7 +158,6 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
         }
     };
     _evaluateJavaScript(nil, nil);
-    [_evaluateJavaScriptLocker unlock];
 }
 
 - (void)_processReceiveArguments:(NSArray*)data

--- a/CBBDataBus/CBBWKWebViewDataBus.m
+++ b/CBBDataBus/CBBWKWebViewDataBus.m
@@ -12,6 +12,7 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
 @property (nonatomic) NSMutableArray<NSString*>* pendingRequests;
 @property (nonatomic) BOOL dataBusFound;
 @property (nonatomic) BOOL consumingRequests;
+@property (nonatomic) void (^evaluateJavaScript)(id, NSError*);
 @end
 
 @implementation CBBWKWebViewDataBus
@@ -139,28 +140,26 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
         return;
     }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-retain-cycles"
-    __block void (^evaluateJavaScript)(id, NSError*) = ^(id ret, NSError* error) {
+    __weak id weakSelf = self;
+    _evaluateJavaScript = ^(id ret, NSError* error) {
         NSString* data;
-        @synchronized(self)
+        @synchronized(weakSelf)
         {
             data = self.pendingRequests.firstObject;
             if (data) {
-                [self.pendingRequests removeObjectAtIndex:0];
+                [((CBBWKWebViewDataBus*)weakSelf).pendingRequests removeObjectAtIndex:0];
             }
         }
         if (data) {
             NSString* script = [NSString stringWithFormat:@"CBB.WebViewDataBus.onData(%@);", data];
-            [self.webView evaluateJavaScript:script
-                           completionHandler:evaluateJavaScript];
+            [((CBBWKWebViewDataBus*)weakSelf).webView evaluateJavaScript:script
+                                                       completionHandler:((CBBWKWebViewDataBus*)weakSelf).evaluateJavaScript];
         } else {
             completionHandler();
         }
     };
-#pragma clang diagnostic pop
 
-    evaluateJavaScript(nil, nil);
+    _evaluateJavaScript(nil, nil);
 }
 
 - (void)_processReceiveArguments:(NSArray*)data

--- a/CBBDataBus/CBBWKWebViewDataBus.m
+++ b/CBBDataBus/CBBWKWebViewDataBus.m
@@ -140,25 +140,22 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
         return;
     }
 
-    __weak __typeof(self) weakSelf = self;
-    _evaluateJavaScript = ^(id ret, NSError* error) {
-        NSString* data;
-        @synchronized(weakSelf)
-        {
-            data = self.pendingRequests.firstObject;
+    @synchronized (self) {
+        __weak __typeof(self) weakSelf = self;
+        _evaluateJavaScript = ^(id ret, NSError* error) {
+            NSString* data  = weakSelf.pendingRequests.firstObject;
             if (data) {
                 [weakSelf.pendingRequests removeObjectAtIndex:0];
             }
-        }
-        if (data) {
-            NSString* script = [NSString stringWithFormat:@"CBB.WebViewDataBus.onData(%@);", data];
-            [weakSelf.webView evaluateJavaScript:script completionHandler:weakSelf.evaluateJavaScript];
-        } else {
-            completionHandler();
-        }
-    };
-
-    _evaluateJavaScript(nil, nil);
+            if (data) {
+                NSString* script = [NSString stringWithFormat:@"CBB.WebViewDataBus.onData(%@);", data];
+                [weakSelf.webView evaluateJavaScript:script completionHandler:weakSelf.evaluateJavaScript];
+            } else {
+                completionHandler();
+            }
+        };
+        _evaluateJavaScript(nil, nil);
+    }
 }
 
 - (void)_processReceiveArguments:(NSArray*)data

--- a/CBBDataBus/CBBWKWebViewDataBus.m
+++ b/CBBDataBus/CBBWKWebViewDataBus.m
@@ -13,7 +13,7 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
 @property (nonatomic) BOOL dataBusFound;
 @property (nonatomic) BOOL consumingRequests;
 @property (nonatomic) void (^evaluateJavaScript)(id, NSError*);
-@property (nonatomic) NSLock* evaluteJavaScriptLocker;
+@property (nonatomic) NSLock* evaluateJavaScriptLocker;
 @end
 
 @implementation CBBWKWebViewDataBus
@@ -29,7 +29,7 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
         _webView = webView;
         _mode = mode;
         _pendingRequests = [NSMutableArray array];
-        _evaluteJavaScriptLocker = [[NSLock alloc] init];
+        _evaluateJavaScriptLocker = [[NSLock alloc] init];
         [self injectCBBDataBus];
     }
     return self;
@@ -142,7 +142,7 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
         return;
     }
 
-    [_evaluteJavaScriptLocker lock];
+    [_evaluateJavaScriptLocker lock];
     __weak __typeof(self) weakSelf = self;
     _evaluateJavaScript = ^(id ret, NSError* error) {
         NSString* data;
@@ -161,7 +161,7 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
         }
     };
     _evaluateJavaScript(nil, nil);
-    [_evaluteJavaScriptLocker unlock];
+    [_evaluateJavaScriptLocker unlock];
 }
 
 - (void)_processReceiveArguments:(NSArray*)data

--- a/CBBDataBus/CBBWKWebViewDataBus.m
+++ b/CBBDataBus/CBBWKWebViewDataBus.m
@@ -140,20 +140,19 @@ static NSString const* CBBLocationHashPrefix = @"cbb-data-bus://";
         return;
     }
 
-    __weak id weakSelf = self;
+    __weak __typeof(self) weakSelf = self;
     _evaluateJavaScript = ^(id ret, NSError* error) {
         NSString* data;
         @synchronized(weakSelf)
         {
             data = self.pendingRequests.firstObject;
             if (data) {
-                [((CBBWKWebViewDataBus*)weakSelf).pendingRequests removeObjectAtIndex:0];
+                [weakSelf.pendingRequests removeObjectAtIndex:0];
             }
         }
         if (data) {
             NSString* script = [NSString stringWithFormat:@"CBB.WebViewDataBus.onData(%@);", data];
-            [((CBBWKWebViewDataBus*)weakSelf).webView evaluateJavaScript:script
-                                                       completionHandler:((CBBWKWebViewDataBus*)weakSelf).evaluateJavaScript];
+            [weakSelf.webView evaluateJavaScript:script completionHandler:weakSelf.evaluateJavaScript];
         } else {
             completionHandler();
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## Version 2.1.2
+- `#pragma clang diagnostic ignored "-Warc-retain-cycles"` で出力抑止していた警告を, 抑止しなくても警告が出ない形に修正
+
 ## Version 2.1.1
 - `CBBWKWebViewDataBus#sendData` を複数スレッドから呼び出すとクラッシュする問題を修正
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ open Example.xcworkspace
 ### Podfile
 ```
 abstract_target 'defaults' do
-    pod 'CBBDataBus', '~2.1.1'
+    pod 'CBBDataBus', '~2.1.2'
 end
 ```
 


### PR DESCRIPTION
`#pragma clang diagnostic ignored "-Warc-retain-cycles"` でブロック変数循環参照の警告を抑止していたが、恐らくswiftプロジェクトでコンパイルすると抑止が効かない可能性があるので、コード修正で警告が出ないようにする。